### PR TITLE
fix typo in autogressive docs

### DIFF
--- a/tensorflow_probability/python/sts/autoregressive.py
+++ b/tensorflow_probability/python/sts/autoregressive.py
@@ -49,7 +49,7 @@ class AutoregressiveStateSpaceModel(tfd.LinearGaussianStateSpaceModel):
   ```python
   level[t+1] = (sum(coefficients * levels[t:t-order:-1]) +
                 Normal(0., level_scale))
-   ```
+  ```
 
   The process is characterized by a vector `coefficients` whose size determines
   the order of the process (how many previous values it looks at), and by


### PR DESCRIPTION
A space before triple tick marks ` ``` ` was causing some bad rendering.

See the [docs for `AutoregressiveStateSpaceModel`](https://www.tensorflow.org/probability/api_docs/python/tfp/sts/AutoregressiveStateSpaceModel). Note the triple tick mark. Image is below, for convenience.

![typo in AutoregressiveStateSpaceModel docs causes bad rendering](https://user-images.githubusercontent.com/13276704/61886637-10cee000-aece-11e9-973c-ac0f70fcf668.png)
